### PR TITLE
Fix size of NAND CTR partition

### DIFF
--- a/source/decryptor/padgen.c
+++ b/source/decryptor/padgen.c
@@ -178,10 +178,10 @@ u32 NandPadgen()
     switch (GetUnitPlatform()) {
         case PLATFORM_3DS:
             keyslot = 0x4;
-            nand_size = 756;
+            nand_size = 758;
         case PLATFORM_N3DS:
             keyslot = 0x5;
-            nand_size = 1054;
+            nand_size = 1055;
     }
 
     Debug("Creating NAND FAT16 xorpad. Size (MB): %u", nand_size);


### PR DESCRIPTION
Use size of partition not file system
0x2F5D0000 = 757.8125 ~ 758
0x41ED0000 = 1054.8125 ~ 1055
