### PR TITLE
Display remaining SD storage space in the main menu.

### DIFF
--- a/source/fs.c
+++ b/source/fs.c
@@ -60,3 +60,24 @@ void FileClose()
 {
     f_close(&file);
 }
+
+static uint64_t ClustersToBytes(FATFS* fs, DWORD clusters)
+{
+    uint64_t sectors = clusters * fs->csize;
+#if _MAX_SS != _MIN_SS
+    return sectors * fs->ssize;
+#else
+    return sectors * _MAX_SS;
+#endif
+}
+
+uint64_t RemainingStorageSpace()
+{
+    DWORD free_clusters;
+    FATFS *fs2;
+    FRESULT res = f_getfree("0:", &free_clusters, &fs2);
+    if (res)
+        return -1;
+
+    return ClustersToBytes(&fs, free_clusters);
+}

--- a/source/fs.h
+++ b/source/fs.h
@@ -20,4 +20,7 @@ size_t FileWrite(void* buf, size_t size, size_t foffset);
 /** Gets the size of the opened file */
 size_t FileGetSize();
 
+/** Gets remaining space on SD card in bytes */
+uint64_t RemainingStorageSpace();
+
 void FileClose();

--- a/source/main.c
+++ b/source/main.c
@@ -33,6 +33,10 @@ int main()
     Debug("Y: NAND Padgen");
     Debug("");
     Debug("START: Reboot");
+    Debug("");
+    Debug("");
+    Debug("Remaining SD storage space: %llu MiB", RemainingStorageSpace() / 1024 / 1024);
+
     while (true) {
         u32 pad_state = InputWait();
         if (pad_state & BUTTON_A) {


### PR DESCRIPTION
NB: We should consider using the standard abbreviation MiB (1024*1024 bytes) in favor of MB (1000*1000 bytes) elsewhere in the source, too.

http://en.wikipedia.org/wiki/Mebibyte
