### PR TITLE
Fixed screen output

### DIFF
--- a/source/decryptor/decryptor.c
+++ b/source/decryptor/decryptor.c
@@ -273,34 +273,34 @@ u32 GetNandCtr(u8* ctr, u32 offset)
         (u8*)0x080D794C
     };
     static const u32 version_ctrs_len = sizeof(version_ctrs) / sizeof(u32);
-	static u8* ctr_start = NULL; 
+    static u8* ctr_start = NULL; 
 
-	if(ctr_start == NULL) {
-		for (u32 i = 0; i < version_ctrs_len; i++) {
-			if (*(u32*)version_ctrs[i] == 0x5C980) {
-				Debug("System version: %s", versions[i]);
-				ctr_start =(u8*)(version_ctrs[i] + 0x30);
-			}
-		}
+    if(ctr_start == NULL) {
+        for (u32 i = 0; i < version_ctrs_len; i++) {
+            if (*(u32*)version_ctrs[i] == 0x5C980) {
+                Debug("System version: %s", versions[i]);
+                ctr_start =(u8*)(version_ctrs[i] + 0x30);
+            }
+        }
 
-		if(ctr_start == NULL) {
-			// if value not in previous list start memory scanning (test range)
-			for (u8* c = (u8*)0x080D8FFF; c > (u8*)0x08000000; c--) {
-				if (*(u32*)c == 0x5C980 && *(u32*)(c + 1) == 0x800005C9) {
-					Debug("CTR Start: 0x%08X", c + 0x30);
-					ctr_start = c + 0x30;
-					break;
-				}
-			}
-		}
-		
-		if(ctr_start == NULL) {
-			Debug("CTR Start: not found!");
-			return 1;
-		}
-	}
-	
-	for (u32 i = 0; i < 16; i++)
+        if(ctr_start == NULL) {
+            // if value not in previous list start memory scanning (test range)
+            for (u8* c = (u8*)0x080D8FFF; c > (u8*)0x08000000; c--) {
+                if (*(u32*)c == 0x5C980 && *(u32*)(c + 1) == 0x800005C9) {
+                    Debug("CTR Start: 0x%08X", c + 0x30);
+                    ctr_start = c + 0x30;
+                    break;
+                }
+            }
+        }
+        
+        if(ctr_start == NULL) {
+            Debug("CTR Start: not found!");
+            return 1;
+        }
+    }
+    
+    for (u32 i = 0; i < 16; i++)
         ctr[i] = *(ctr_start + (0xF - i)); // The CTR is stored backwards in memory.
     add_ctr(ctr, offset / 0x10);
 
@@ -317,9 +317,9 @@ u32 SeekMagicNumber(u8* magic, u32 magiclen, u32 offset, u32 size, u32 keyslot)
     info.setKeyY = 0;
     info.size = NAND_SECTOR_SIZE;
     info.buffer = buffer;
-	if(GetNandCtr(info.CTR, offset) != 0)
-		return 1;
-	
+    if(GetNandCtr(info.CTR, offset) != 0)
+        return 1;
+    
     u32 n_sectors = size / NAND_SECTOR_SIZE;
     u32 start_sector = offset / NAND_SECTOR_SIZE;
     for (u32 i = 0; i < n_sectors; i++) {
@@ -350,8 +350,8 @@ u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot)
     info.setKeyY = 0;
     info.size = SECTORS_PER_READ * NAND_SECTOR_SIZE;
     info.buffer = buffer;
-	if(GetNandCtr(info.CTR, offset) != 0)
-		return 1;
+    if(GetNandCtr(info.CTR, offset) != 0)
+        return 1;
 
     if (!FileCreate(filename, true))
         return 1;
@@ -374,17 +374,17 @@ u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot)
 
 u32 NandPadgen()
 {
-	u8 ctr[16];
-	u32 keyslot;
+    u8 ctr[16];
+    u32 keyslot;
     u32 nand_size;
-	
-	if(GetNandCtr(ctr, 0xB930000) != 0)
-		return 1;
+    
+    if(GetNandCtr(ctr, 0xB930000) != 0)
+        return 1;
 
     if(GetUnitPlatform() == PLATFORM_3DS) {
-		keyslot = 0x4;
-		nand_size = 758;
-	} else {
+        keyslot = 0x4;
+        nand_size = 758;
+    } else {
         keyslot = 0x5;
         nand_size = 1055;
     }
@@ -393,8 +393,8 @@ u32 NandPadgen()
     Debug("Filename: nand.fat16.xorpad");
 
     PadInfo padInfo = {.keyslot = keyslot, .setKeyY = 0, .size_mb = nand_size , .filename = "/nand.fat16.xorpad"};
-	if(GetNandCtr(padInfo.CTR, 0xB930000) != 0)
-		return 1;
+    if(GetNandCtr(padInfo.CTR, 0xB930000) != 0)
+        return 1;
 
     return CreatePad(&padInfo);
 }

--- a/source/decryptor/decryptor.c
+++ b/source/decryptor/decryptor.c
@@ -296,15 +296,15 @@ static u8* FindNandCtr()
 
 u32 SeekMagicNumber(u8* magic, u32 magiclen, u32 offset, u32 size, u32 keyslot)
 {
-	DecryptBufferInfo info;
+    DecryptBufferInfo info;
     u8* buffer = BUFFER_ADDRESS;
-	u32 found = (u32) -1;
+    u32 found = (u32) -1;
 
-	if (ctrStart == NULL) {
-		ctrStart = FindNandCtr();
+    if (ctrStart == NULL) {
+        ctrStart = FindNandCtr();
         if (ctrStart == NULL)
             return 1;
-	}
+    }
 
     info.keyslot = keyslot;
     info.setKeyY = 0;
@@ -321,10 +321,10 @@ u32 SeekMagicNumber(u8* magic, u32 magiclen, u32 offset, u32 size, u32 keyslot)
         ShowProgress(i, n_sectors);
         sdmmc_nand_readsectors(start_sector + i, 1, buffer);
         DecryptBuffer(&info);
-		if(memcmp(buffer, magic, magiclen) == 0) {
-			found = (start_sector + i) * NAND_SECTOR_SIZE;
-			break;
-		}
+        if(memcmp(buffer, magic, magiclen) == 0) {
+            found = (start_sector + i) * NAND_SECTOR_SIZE;
+            break;
+        }
     }
 
     ShowProgress(0, 0);
@@ -341,11 +341,11 @@ u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot)
     Debug("Decrypting NAND data. Size (MB): %u", offset, size);
     Debug("Filename: %s", filename);
 
-	if (ctrStart == NULL) {
-		ctrStart = FindNandCtr();
+    if (ctrStart == NULL) {
+        ctrStart = FindNandCtr();
         if (ctrStart == NULL)
             return 1;
-	}
+    }
 
     info.keyslot = keyslot;
     info.setKeyY = 0;
@@ -362,7 +362,7 @@ u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot)
     u32 n_sectors = size / NAND_SECTOR_SIZE;
     u32 start_sector = offset / NAND_SECTOR_SIZE;
     for (u32 i = 0; i < n_sectors; i += SECTORS_PER_READ) {
-		u32 read_sectors = min(SECTORS_PER_READ, (n_sectors - i));
+        u32 read_sectors = min(SECTORS_PER_READ, (n_sectors - i));
         ShowProgress(i, n_sectors);
         sdmmc_nand_readsectors(start_sector + i, read_sectors, buffer);
         DecryptBuffer(&info);
@@ -378,10 +378,10 @@ u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot)
 u32 NandPadgen()
 {
     if (ctrStart == NULL) {
-		ctrStart = FindNandCtr();
+        ctrStart = FindNandCtr();
         if (ctrStart == NULL)
             return 1;
-	}
+    }
 
     u8 ctr[16] = {0x0};
     u32 i = 0;
@@ -494,7 +494,7 @@ u32 NandPartitionsDumper() {
         ctrnand_offset = 0x0B95CA00;
         ctrnand_size = 0x2F3E3600;
         keyslot = 0x4;
-	} else {
+    } else {
         ctrnand_offset = 0x0B95AE00;
         ctrnand_size = 0x41D2D200;
         keyslot = 0x5;
@@ -509,29 +509,29 @@ u32 NandPartitionsDumper() {
 }
 
 u32 TicketDumper() {
-	const u32 ticket_size = 0xD0000;
-	u32 ctrnand_offset;
+    const u32 ticket_size = 0xD0000;
+    u32 ctrnand_offset;
     u32 ctrnand_size;
     u32 keyslot;
-	u32 offset;
+    u32 offset;
 
     if(GetUnitPlatform() == PLATFORM_3DS) {
         ctrnand_offset = 0x0B95CA00;
         ctrnand_size = 0x2F3E3600;
         keyslot = 0x4;
-	} else {
+    } else {
         ctrnand_offset = 0x0B95AE00;
         ctrnand_size = 0x41D2D200;
         keyslot = 0x5;
     }
-	
+    
     Debug("Seeking for 'TICK'...");
-	offset = SeekMagicNumber((u8*) "TICK", 4, ctrnand_offset, ctrnand_size - ticket_size + NAND_SECTOR_SIZE, keyslot);
-	if(offset == (u32) -1) {
-		Debug("Failed!");
-		return 1;
-	}
-	Debug("Found at 0x%08X", offset);
-	
-	return DumpPartition("ticket.bin", offset, ticket_size, keyslot);
+    offset = SeekMagicNumber((u8*) "TICK", 4, ctrnand_offset, ctrnand_size - ticket_size + NAND_SECTOR_SIZE, keyslot);
+    if(offset == (u32) -1) {
+        Debug("Failed!");
+        return 1;
+    }
+    Debug("Found at 0x%08X", offset);
+    
+    return DumpPartition("ticket.bin", offset, ticket_size, keyslot);
 }

--- a/source/decryptor/decryptor.h
+++ b/source/decryptor/decryptor.h
@@ -77,4 +77,8 @@ typedef struct {
     TitleKeyEntry entries[MAX_ENTRIES];
 } __attribute__((packed, aligned(16))) EncKeysInfo;
 
+static u8* FindNandCtr();
+u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot);
+u32 DecryptBuffer(DecryptBufferInfo *info);
 u32 CreatePad(PadInfo *info);
+

--- a/source/decryptor/decryptor.h
+++ b/source/decryptor/decryptor.h
@@ -77,8 +77,7 @@ typedef struct {
     TitleKeyEntry entries[MAX_ENTRIES];
 } __attribute__((packed, aligned(16))) EncKeysInfo;
 
-static u8* FindNandCtr();
+u32 GetNandCtr(u8* ctr, u32 offset);
 u32 DumpPartition(char* filename, u32 offset, u32 size, u32 keyslot);
 u32 DecryptBuffer(DecryptBufferInfo *info);
 u32 CreatePad(PadInfo *info);
-

--- a/source/decryptor/features.h
+++ b/source/decryptor/features.h
@@ -5,4 +5,5 @@ u32 SdPadgen(void);
 u32 NandPadgen(void);
 u32 DecryptTitlekeys(void);
 u32 NandDumper(void);
-u32 NandPartitionsDumper();
+u32 NandPartitionsDumper(void);
+u32 TicketDumper(void);

--- a/source/draw.c
+++ b/source/draw.c
@@ -84,8 +84,8 @@ void Debug(const char *format, ...)
     va_start(va, format);
     vsnprintf(str, 256, format, va);
     va_end(va);
-	
-	if (current_y >= END_Y) {
+    
+    if (current_y >= END_Y) {
         DebugClear();
     }
 

--- a/source/draw.c
+++ b/source/draw.c
@@ -58,16 +58,15 @@ void DrawString(u8* screen, const char *str, int x, int y, int color, int bgcolo
 
 void DrawStringF(int x, int y, const char *format, ...)
 {
-    char* str;
+    char str[256];
     va_list va;
 
     va_start(va, format);
-    vasprintf(&str, format, va);
+    vsnprintf(str, 256, format, va);
     va_end(va);
 
     DrawString(TOP_SCREEN0, str, x, y, FONT_COLOR, BG_COLOR);
     DrawString(TOP_SCREEN1, str, x, y, FONT_COLOR, BG_COLOR);
-    free(str);
 }
 
 void DebugClear()
@@ -79,16 +78,19 @@ void DebugClear()
 
 void Debug(const char *format, ...)
 {
-    char* str;
+    char str[256];
     va_list va;
 
     va_start(va, format);
-    vasprintf(&str, format, va);
+    vsnprintf(str, 256, format, va);
     va_end(va);
+	
+	if (current_y >= END_Y) {
+        DebugClear();
+    }
 
     DrawString(TOP_SCREEN0, str, 10, current_y, FONT_COLOR, BG_COLOR);
     DrawString(TOP_SCREEN1, str, 10, current_y, FONT_COLOR, BG_COLOR);
-    free(str);
 
     current_y += 10;
 }

--- a/source/main.c
+++ b/source/main.c
@@ -26,6 +26,7 @@ int main()
     Debug("Y: NAND Padgen");
     Debug("L: NAND Partition Dump");
     Debug("R: NAND Dump");
+	Debug("%c: Ticket Dump", 0x18);
     Debug("");
     Debug("START: Reboot");
     Debug("");
@@ -57,6 +58,10 @@ int main()
         } else if (pad_state & BUTTON_R1) {
             DebugClear();
             Debug("NAND Dump: %s!", NandDumper() == 0 ? "succeeded" : "failed");
+            break;
+        } else if (pad_state & BUTTON_UP) {
+            DebugClear();
+            Debug("Ticket Dump: %s!", TicketDumper() == 0 ? "succeeded" : "failed");
             break;
         } else if (pad_state & BUTTON_START) {
             goto reboot;

--- a/source/main.c
+++ b/source/main.c
@@ -26,7 +26,7 @@ int main()
     Debug("Y: NAND Padgen");
     Debug("L: NAND Partition Dump");
     Debug("R: NAND Dump");
-	Debug("%c: Ticket Dump", 0x18);
+    Debug("%c: Ticket Dump", 0x18);
     Debug("");
     Debug("START: Reboot");
     Debug("");


### PR DESCRIPTION
vasprintf() breaks the output for me (on Brahma).

Clearing the screen makes sense, because some ncchinfo.bin files
completely fill the screen with Debug messages, leading to bad output
otherwise.
