### PR TITLE
Fixing NAND size detection

### DIFF
--- a/source/decryptor/decryptor.c
+++ b/source/decryptor/decryptor.c
@@ -8,6 +8,7 @@
 #include "decryptor/crypto.h"
 #include "decryptor/features.h"
 #include "sha256.h"
+#include "fatfs/sdmmc.h"
 
 #define BUFFER_ADDRESS  ((u8*) 0x21000000)
 #define BUFFER_MAX_SIZE (1 * 1024 * 1024)
@@ -463,7 +464,7 @@ u32 CreatePad(PadInfo *info)
 u32 DumpNand()
 {
     u8* buffer = BUFFER_ADDRESS;
-    u32 nand_size = (GetUnitPlatform() == PLATFORM_3DS) ? 0x3AF00000 : 0x4D800000;
+    u32 nand_size = getMMCDevice(0)->total_size * 0x200;
     u32 result = 0;
 
     Debug("Dumping System NAND. Size (MB): %u", nand_size / (1024 * 1024));

--- a/source/fatfs/sdmmc.c
+++ b/source/fatfs/sdmmc.c
@@ -226,32 +226,30 @@ int __attribute__((noinline)) sdmmc_nand_writesectors(u32 sector_no, u32 numsect
     return geterror(&handleNAND);
 }
 
-u32 calcSDSize(u8* csd, int type)
+static u32 calcSDSize(u8* csd, int type)
 {
     u32 result = 0;
-    u8 temp = csd[0xE];
-    //int temp3 = type;
-
+    if (type == -1) type = csd[14] >> 6;
     switch (type) {
-        case -1:
-            type = temp >> 6;
-            break;
         case 0:
-        {
-            u32 temp = (csd[0x7] << 0x2 | csd[0x8] << 0xA | csd[0x6] >> 0x6 | (csd[0x9] & 0xF) << 0x10) & 0xFFF;
-            u32 temp2 = temp * (1 << (csd[0x9] & 0xF));
-            u32 retval = temp2 * (1 << (((csd[0x4] >> 7 | csd[0x5] << 1) & 7) + 2));
-            result = retval >> 9;
+            {
+                u32 block_len = csd[9] & 0xf;
+                block_len = 1 << block_len;
+                u32 mult = (csd[4] >> 7) | ((csd[5] & 3) << 1);
+                mult = 1 << (mult + 2);
+                result = csd[8] & 3;
+                result = (result << 8) | csd[7];
+                result = (result << 2) | (csd[6] >> 6);
+                result = (result + 1) * mult * block_len / 512;
+            }
             break;
-        }
         case 1:
-            result = (((csd[0x7] & 0x3F) << 0x10 | csd[0x6] << 8 | csd[0x5]) + 1) << 0xA;
-            break;
-        default:
-            result = 0;
+            result = csd[7] & 0x3f;
+            result = (result << 8) | csd[6];
+            result = (result << 8) | csd[5];
+            result = (result + 1) * 1024;
             break;
     }
-
     return result;
 }
 


### PR DESCRIPTION
Relevant issues: https://github.com/mid-kid/CakesForeveryWan/issues/8 and https://github.com/roxas75/rxTools/issues/208
Different consoles have different NAND sizes. This patch detects the size properly, without anything hardcoded.
